### PR TITLE
Trim redundant `-stable` from version number result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           gdrive-target-base-dir: ${{ vars.GDRIVE_TARGET_BASE_DIR }}
           gdrive-secret-key: ${{ secrets.GOOGLE_DRIVE_KEY }}
           gdrive-parent-folder-id: ${{ secrets.GOOGLE_DRIVE_TECH_DRIVE }}
-          package-version: ${{ env.DESKFLOW_VERSION }}
+          package-version: ${{ env.SYNERGY_VERSION }}
 
   macos:
     name: ${{ matrix.target.name }}
@@ -213,7 +213,7 @@ jobs:
           gdrive-target-base-dir: ${{ vars.GDRIVE_TARGET_BASE_DIR }}
           gdrive-secret-key: ${{ secrets.GOOGLE_DRIVE_KEY }}
           gdrive-parent-folder-id: ${{ secrets.GOOGLE_DRIVE_TECH_DRIVE }}
-          package-version: ${{ env.DESKFLOW_VERSION }}
+          package-version: ${{ env.SYNERGY_VERSION }}
 
   linux-matrix:
     runs-on: ubuntu-latest
@@ -318,4 +318,4 @@ jobs:
           gdrive-target-base-dir: ${{ vars.GDRIVE_TARGET_BASE_DIR }}
           gdrive-secret-key: ${{ secrets.GOOGLE_DRIVE_KEY }}
           gdrive-parent-folder-id: ${{ secrets.GOOGLE_DRIVE_TECH_DRIVE }}
-          package-version: ${{ env.DESKFLOW_VERSION }}
+          package-version: ${{ env.SYNERGY_VERSION }}


### PR DESCRIPTION
https://github.com/symless/synergy-odin/pull/24